### PR TITLE
feat: add devcontainer configuration

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -18,6 +18,13 @@
 	// Use this environment variable if you need to bind mount your local source code into a new container.
 	"remoteEnv": {
 		"LOCAL_WORKSPACE_FOLDER": "${localWorkspaceFolder}"
+	},
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"humao.rest-client"
+			]
+		}
 	}
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,34 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/docker-outside-of-docker
+{
+	"name": "Docker outside of Docker",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	"image": "mcr.microsoft.com/devcontainers/base:bullseye",
+
+	"features": {
+		"ghcr.io/devcontainers/features/docker-from-docker:1": {
+			"version": "latest",
+			"enableNonRootDocker": "true",
+			"moby": "false"
+		},
+		"ghcr.io/devcontainers/features/node:1": {},
+		"ghcr.io/devcontainers/features/azure-cli:1": {}
+	},
+
+	// Use this environment variable if you need to bind mount your local source code into a new container.
+	"remoteEnv": {
+		"LOCAL_WORKSPACE_FOLDER": "${localWorkspaceFolder}"
+	}
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "docker --version",
+
+	// Configure tool-specific properties.
+	// "customizations": {},
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}


### PR DESCRIPTION
## TODO
- [ ] Cosmos DB Emulator

## Description
This PR add a .devcontainer configuration that: 
- Allow docker-in-docker (we're deploying docker images/micro-services on host)
- Run the dev env in a container with Node.JS + AZ CLI (so you don't need it on your machine)

I've created a draft PR because I didn't managed to get the solution working. 
- Settings API is running
- Dice API is running
- Gateway is either not launching or having trouble to "heartbeat" the other APIs (localhost/docker network issues)

Example running `docker-compose up`
![image](https://user-images.githubusercontent.com/790974/208720733-0a066aa9-b400-4147-bc28-df6f4448b651.png)

Example running `npm start`, where I have issue with SWA Emulator (and localhost)

![image](https://user-images.githubusercontent.com/790974/208721104-bc8e03ef-b8b1-42bc-a329-6d04fed7a4ec.png)

![image](https://user-images.githubusercontent.com/790974/208721351-5d07d1bb-cb81-4e7a-b456-b88fac9afde5.png)

